### PR TITLE
Add a very simple lexer generator.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,6 +14,7 @@ import System.Exit (exitFailure)
 import ParallelParser.LL (closureAlgorithm)
 import qualified Data.Set as Set
 import ParallelParser.CFG
+import ParallelParser.Lexer
 import Debug.Trace (traceShow)
 
 debug :: Show b => b -> b
@@ -127,8 +128,18 @@ main = do
   contents <- case input_method of
         StdInput -> T.getContents
         FileInput path -> T.readFile path
+  cfg <-
+    case cfgFromText program_path contents of
+        Left e -> do hPutStrLn stderr e
+                     exitFailure
+        Right g -> pure g
   grammar <-
-      case fmap unpackNTTGrammar . cfgToGrammar =<< cfgFromText program_path contents of
+      case unpackNTTGrammar <$> cfgToGrammar cfg of
+        Left e -> do hPutStrLn stderr e
+                     exitFailure
+        Right g -> pure g
+  lexer <-
+      case cfgToLexer cfg of
         Left e -> do hPutStrLn stderr e
                      exitFailure
         Right g -> pure g
@@ -138,4 +149,8 @@ main = do
     Nothing -> case maybe_program of
         Left e -> do hPutStrLn stderr e
                      exitFailure
-        Right program -> writeFutharkProgram program_path program
+        Right program ->
+          writeFutharkProgram program_path $
+            program <>
+            generateLexer lexer <>
+            "entry parse s = parser.parse (lex char_code accept s)\n"

--- a/fut/.gitignore
+++ b/fut/.gitignore
@@ -1,0 +1,2 @@
+lib
+futhark.pkg

--- a/fut/parser.fut
+++ b/fut/parser.fut
@@ -111,4 +111,15 @@ module mk_parser(G: grammar) = {
           else []
 }
 
+def lexer_error = u32.highest-2
+def whitespace = u32.highest-1
+
+def terminals [n] (accept: u32 -> u32 -> u32) (xs: [n]u32) : []terminal =
+  let f i a b = accept a (if i == n-1 then whitespace else b)
+  in map3 f (indices xs) xs (rotate 1 xs)
+     |> filter (!=whitespace)
+
+def lex (char_code: u8 -> u32) (accept: u32 -> u32 -> u32) (s: []u8) : []terminal =
+  terminals accept (map char_code s)
+
 -- End of parser.fut

--- a/grammars/sexp.cg
+++ b/grammars/sexp.cg
@@ -1,4 +1,4 @@
-atom = [a-z]+;
+atom = [a-z0-9]+;
 
 E = atom | "(" E0 ")";
 E0 = | E E0;

--- a/parallel-parser.cabal
+++ b/parallel-parser.cabal
@@ -12,7 +12,7 @@ license-file:       LICENSE
 author:             William Due
 maintainer:         williamhenrichdue@gmail.com
 category:           Language
-extra-source-files: CHANGELOG.md
+extra-source-files: CHANGELOG.md fut/parser.fut
 
 library
   default-language:   GHC2021
@@ -49,11 +49,9 @@ library
     ParallelParser.LL
     ParallelParser.LLP
     ParallelParser.Generator
+    ParallelParser.Lexer
 
   hs-source-dirs:     src
-
-  extra-source-files:
-    fut/parser.fut
 
   ghc-options:        -O2 -Wall
 

--- a/src/ParallelParser/CFG.hs
+++ b/src/ParallelParser/CFG.hs
@@ -1,6 +1,7 @@
 module ParallelParser.CFG
   ( cfgFromText,
     cfgToGrammar,
+    cfgToLexer,
     CFG (..),
     TRule (..),
     NTRule (..),
@@ -9,11 +10,12 @@ where
 
 import Control.Monad (void)
 import Data.Char (isAlphaNum, isLower, isPrint, isUpper)
-import Data.List (nub)
+import Data.List (nub, nubBy)
 import Data.Set qualified as S
 import Data.Text qualified as T
 import Data.Void
 import ParallelParser.Grammar
+import ParallelParser.Lexer
 import Text.Megaparsec
 import Text.Megaparsec.Char (char, space1)
 import Text.Megaparsec.Char.Lexer qualified as Lexer
@@ -44,6 +46,13 @@ data CFG = CFG
   }
   deriving (Show)
 
+symbolTerminal :: Symbol NT T -> S.Set T
+symbolTerminal (Terminal t) = S.singleton t
+symbolTerminal (Nonterminal _) = mempty
+
+ruleTerminals :: NTRule -> S.Set T
+ruleTerminals = foldMap (foldMap symbolTerminal) . ruleProductions
+
 cfgToGrammar :: CFG -> Either String (Grammar NT T)
 cfgToGrammar (CFG {ntRules = []}) = Left "CFG has no production rules."
 cfgToGrammar (CFG {tRules, ntRules}) =
@@ -53,11 +62,24 @@ cfgToGrammar (CFG {tRules, ntRules}) =
       terminals = nub $ map ruleT tRules ++ S.toList (foldMap ruleTerminals ntRules)
    in Right $ Grammar {start, terminals, nonterminals, productions}
   where
-    symbolTerminal (Terminal t) = S.singleton t
-    symbolTerminal (Nonterminal _) = mempty
     ruleProds NTRule {ruleNT, ruleProductions} =
       map (Production ruleNT) ruleProductions
-    ruleTerminals = foldMap (foldMap symbolTerminal) . ruleProductions
+
+cfgToLexer :: CFG -> Either String [LexerRule]
+cfgToLexer (CFG {tRules, ntRules}) =
+  mapM rule $ nubBy sameT $ tRules <> map mkImplicitRule implicit
+  where
+    sameT x y = ruleT x == ruleT y
+    declared = map ruleT tRules
+    implicit = filter (`notElem` declared) $ S.toList $ foldMap ruleTerminals ntRules
+    rule (TRule {ruleRegex = RegexConst s})
+      | [c] <- T.unpack s =
+          Right $ LChar c
+    rule (TRule {ruleRegex = RegexSpanPlus x y}) =
+      Right $ LChars x y
+    rule (TRule {ruleT = T s}) =
+      Left $ "Cannot handle rule for terminal " <> s
+    mkImplicitRule (T t) = TRule {ruleT = T t, ruleRegex = RegexConst $ T.pack t}
 
 type Parser = Parsec Void T.Text
 

--- a/src/ParallelParser/Generator.hs
+++ b/src/ParallelParser/Generator.hs
@@ -176,8 +176,6 @@ def ne : ([max_ao]bracket, [max_pi]u32) =
   let (a,b) = #{ne}
   in (sized max_ao a, sized max_pi b)
 }
-
-entry parse = parser.parse
 |]
   where
     maybe_start_terminal = List.elemIndex RightTurnstile terminals' :: Maybe Int

--- a/src/ParallelParser/Lexer.hs
+++ b/src/ParallelParser/Lexer.hs
@@ -9,11 +9,15 @@ import Data.String.Interpolate (i)
 
 data LexerRule
   = LChar Char -- "c"
-  | LChars Char Char -- [x-y]+
+  | LChars [(Char, Char)] -- [x-y]+
 
 charMatches :: LexerRule -> String
 charMatches (LChar c) = [i|c == #{ord c}|]
-charMatches (LChars x y) = [i|c >= #{ord x} && c <= #{ord y}|]
+charMatches (LChars []) = "false"
+charMatches (LChars [(x, y)]) =
+  [i|c >= #{ord x} && c <= #{ord y}|]
+charMatches (LChars ((x, y) : xys)) =
+  [i|c >= #{ord x} && c <= #{ord y} || #{charMatches (LChars xys)}|]
 
 mapFunction :: [LexerRule] -> String
 mapFunction rules =

--- a/src/ParallelParser/Lexer.hs
+++ b/src/ParallelParser/Lexer.hs
@@ -1,0 +1,49 @@
+module ParallelParser.Lexer
+  ( LexerRule (..),
+    generateLexer,
+  )
+where
+
+import Data.Char (ord)
+import Data.String.Interpolate (i)
+
+data LexerRule
+  = LChar Char -- "c"
+  | LChars Char Char -- [x-y]+
+
+charMatches :: LexerRule -> String
+charMatches (LChar c) = [i|c == #{ord c}|]
+charMatches (LChars x y) = [i|c >= #{ord x} && c <= #{ord y}|]
+
+mapFunction :: [LexerRule] -> String
+mapFunction rules =
+  [i|def char_code (c: u8) : u32 =
+       #{branches (zip [(0::Int)..] rules)}|]
+  where
+    branches [] = "if c == ' ' then whitespace else lexer_error"
+    branches ((l, r) : rs) =
+      [i|if #{charMatches r} then #{l} else
+         #{branches rs}|]
+
+acceptFunction :: [LexerRule] -> String
+acceptFunction rules =
+  [i|def accept (this: u32) (next: u32) =
+       #{branches (zip [(0::Int)..] rules)}|]
+  where
+    branches [] = "if this == lexer_error then lexer_error else whitespace"
+    branches ((l, LChar {}) : rs) =
+      [i|if this == #{l} then this
+         else #{branches rs}|]
+    branches ((l, LChars {}) : rs) =
+      [i|if this == #{l} && next != #{l} then this
+         else #{branches rs}|]
+
+-- | The rules must currently be be completely disjoint.  The order in
+-- which they occur determines which integer is associated with each
+-- lexeme.
+generateLexer :: [LexerRule] -> String
+generateLexer rules =
+  unlines
+    [ mapFunction rules,
+      acceptFunction rules
+    ]


### PR DESCRIPTION
The lexemes must be completely disjoint, such that by observing a single character we can immediately decide which terminal (if any) it belongs to.

Whitespace is hardcoded.

This obviously needs significantly more work, but it's actually enough to parse Lisp expressions such as

    (define (fib n) (if (= n 0) 1 (mul n (fib (dec 1)))))

which with the sexp.cg grammar gives

    [1, 3, 0, 3, 1, 3, 0, 3, 0, 2, 3, 1, 3, 0, 3, 1, 3, 0, 2, 3, 1, 3, 0, 3, 0, 3, 1, 3, 0, 3, 1, 3, 0, 2, 2, 2, 2, 2]